### PR TITLE
Update amount representation from subunits to decimal

### DIFF
--- a/TAIPs/taip-3.md
+++ b/TAIPs/taip-3.md
@@ -72,9 +72,7 @@ are defined:
 - `@type` - REQUIRED the JSON-LD type `https://tap.rsvp/schema/1.0#Transfer`
   (provisional)
 - `asset` - REQUIRED the [CAIP-19](CAIP-19) identifier of the asset
-- `amountSubunits` - OPTIONAL for NFTs and REQUIRED for fungible tokens.
-  Specified as a string with the full amount in integer in the smallest subunit
-  of a token
+- `amount` - OPTIONAL for NFTs and REQUIRED for fungible tokens. Specified as a string with the full amount as a decimal representation of the token
 - `originator` - OPTIONAL an object representing the originating (aka the
   sender) party (see [TAIP-6](TAIP-6))
 - `beneficiary` - OPTIONAL an object representing the beneficiary (aka the
@@ -91,14 +89,9 @@ be expanded and modified collaboratively by the agents of a transaction.
 
 #### Transfer Amounts
 
-The amount of a transfer is specified as `amountSubunits` as it is the most
-precise representation of an amount and is, in most cases, the same as used in
-the underlying blockchain protocol. For many application developers, this can be
-error-prone. It is the responsibility of library and tool developers to help
-educate and help convert between commonly used decimal amounts and the
-underlying sub-unit.
+The amount of a transfer is specified as `amount` and represents the decimal value of the asset. This approach is more intuitive for most users and application developers. It is the responsibility of library and tool developers to handle any necessary conversions when interacting with blockchain protocols that may require amounts in their smallest units.
 
-As an example `ETH 1.23` should be encoded as `1230000000000000000`.
+As an example, `ETH 1.23` should be encoded as `"1.23"`.
 
 #### `settlementId`
 
@@ -170,7 +163,7 @@ firm to the ethereum wallet with the address
     "originator": {
       "@id": "did:web:originator.sample"
     },
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "agents": [
       {
         "@id": "did:web:originator.sample"
@@ -204,7 +197,7 @@ from a customer to the ethereum wallet with the address
     "originator": {
       "@id": "did:eg:bob"
     },
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "agents": [
       {
         "@id": "did:web:originator.vasp"
@@ -242,7 +235,7 @@ the authorization flow:
     "beneficiary": {
       "@id": "sms:+15105550101"
     },
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "agents": [
       {
         "@id": "did:web:originator.vasp"
@@ -278,7 +271,7 @@ settled transaction.
       "@id": "did:eg:alice"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId": "eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents": [
       {

--- a/TAIPs/taip-5.md
+++ b/TAIPs/taip-5.md
@@ -76,7 +76,7 @@ The following example shows its use in a [TAIP-3] message:
     "originator": {
       "@id": "did:web:originator.sample"
     },
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "agents": [
       {
         "@id": "did:web:originator.sample"
@@ -380,7 +380,7 @@ customer is asking to transfer funds to a blockchain address:
       "@id": "did:eg:bob"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId": "eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents": [
       {
@@ -421,7 +421,7 @@ Address:
       "@id": "did:eg:alice"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId": "eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents": [
       {
@@ -475,7 +475,7 @@ goes to the customer's own self-hosted wallet address:
       "@id": "did:eg:bob"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId": "eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents": [
       {

--- a/TAIPs/taip-6.md
+++ b/TAIPs/taip-6.md
@@ -175,7 +175,7 @@ transaction::
       "@id": "did:eg:bob"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId": "eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents": [
       {
@@ -216,7 +216,7 @@ Address. It now has all the required information to complete it:
       "@id": "did:eg:alice"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId": "eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents": [
       {
@@ -266,7 +266,7 @@ goes to the customer’s self-hosted wallet address:
       "@id": "did:eg:bob"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId": "eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents": [
       {

--- a/TAIPs/taip-9.md
+++ b/TAIPs/taip-9.md
@@ -71,7 +71,7 @@ As an example see the following [TAIP-3] object:
       "@id": "did:eg:alice"
     },
     "asset": "eip155:1/slip44:60",
-    "amountSubunits": "1230000000000000000",
+    "amount": "1.23",
     "settlementId": "eip155:1:tx/0x3edb98c24d46d148eb926c714f4fbaa117c47b0c0821f38bfce9763604457c33",
     "agents": [
       {


### PR DESCRIPTION
- Replace 'amountSubunits' with 'amount' in all TAIPs
- Change amount representation from smallest units to decimal values
- Update examples to use decimal amounts (e.g., 1.23 instead of 1230000000000000000)
- Adjust descriptions to reflect the new decimal representation